### PR TITLE
include topic context in suggestion forms

### DIFF
--- a/bluepages/app/templates/contact_suggestion_menu.html
+++ b/bluepages/app/templates/contact_suggestion_menu.html
@@ -77,7 +77,7 @@
     {% endif %}
     {% for record in contact.records %}
         <div class="contact-record-menu-entry row" >
-            <div class="col-8"><b>{{ record.topic }}</b></div>
+            <div class="col-8 {{ record.status }}"><b>{{ record.topic }}</b></div>
             <div class="col-4">
                 <button class="btn btn-primary" onclick="app.prepRecordSuggestions({{ contact.id }}, {{ record.id }})">Edit</button>
                 <button class="btn btn-danger" onclick="app.deleteRecordSuggestions({{ contact.id }}, {{ record.id }})">Delete</button>

--- a/bluepages/app/templates/suggestion_menu.html
+++ b/bluepages/app/templates/suggestion_menu.html
@@ -12,7 +12,7 @@
                     Topics:
                     <ul>
                     {% for record in suggestion.topics %}
-                            <li>{{ record.topic }}</li>
+                            <li class="{{ record.status }}">{{ record.topic }}</li>
                         {% endfor %}
                     </ul>
                 {% else %}

--- a/bluepages/app/views.py
+++ b/bluepages/app/views.py
@@ -179,7 +179,7 @@ def getSuggestionMenu(request):
             'description': contact_suggestion.description,
             'date_created': contact_suggestion.date_created.strftime('%m/%d/%Y %I:%M %p'),
             'date_modified': contact_suggestion.date_modified.strftime('%m/%d/%Y %I:%M %p'),
-            'topics': [{'id': x.pk, 'topic': str(x.topic), 'topic_id': x.topic.pk} for x in contact_suggestion.recordsuggestion_set.all()]
+            'topics': [{'id': x.pk, 'topic': str(x.topic), 'topic_id': x.topic.pk, 'status': x.status} for x in contact_suggestion.recordsuggestion_set.all()]
         } 
         for contact_suggestion in ContactSuggestion.objects.filter(user=request.user).order_by('status', 'last_name', 'first_name', 'date_modified', 'date_created')
     ]


### PR DESCRIPTION
Exposing the status of contact topic ('record') suggestions to the templates, along with template changes to demonstrate (maybe even implement) use of the status for visually presenting this information to users.