### PR TITLE
refactor get_host_ip method to use route for host IP detection

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,8 +2,11 @@
 # vi: set ft=ruby :
 
 def get_host_ip
-  # This example uses `ifconfig` and `grep` to find inet interface and host IP address
-  host_ip = `ifconfig | grep "inet " | grep -v 127.0.0.1 | awk '{print $2}'`.strip
+  # This uses `route` to find the host's default IP address 
+  # and pipes it through to `awk` and `ifconfig`  
+  # to extract the IP address of the host machine.
+  host_ip = `route -n get default | awk '/interface:/{print $2}' | xargs ifconfig | awk '/inet / {print $2}'`.strip
+
   return host_ip
 end
 


### PR DESCRIPTION
Updates the `Vagrantfile` to use a more robust `get_host_ip` method. Increases the likely hood of only one IP address being returned, bc more than one causes a vagrant error that looks like:

```zsh
Failed to mount folders in Linux guest. This is usually because the "vboxsf" file system is not available. Please verify that the guest additions are properly installed in the guest and can work properly. 

The command attempted was: mount -t cifs -o sec=ntlmssp,nounix,noperm,credentials=/etc/smb_creds_vgt-4a82863d8d3fe61c5cc456cafda2a689-ac1b791f827cf72cc7e905345947e259,uid=1000,gid=1000,mfsymlinks,_netdev,vers=3.0 //169.254.13.159 192.168.86.131/vgt-4a82863d8d3fe61c5cc456cafda2a689-ac1b791f827cf72cc7e905345947e259 /usr/local/apps/madrona_portal 

The error output from the last command was: 

mount: //169.254.13.159: can't find in /etc/fstab. bash: line 6: 192.168.86.131/vgt-4a82863d8d3fe61c5cc456cafda2a689-ac1b791f827cf72cc7e905345947e259: No such file or directory
```