### PR TITLE
attach ssm policy to ec2 role

### DIFF
--- a/infra/iam.tf
+++ b/infra/iam.tf
@@ -28,6 +28,10 @@ resource "aws_iam_role_policy" "bluepages_s3_read" {
     ]
   })
 }
+resource "aws_iam_role_policy_attachment" "ssm_core" {
+  role       = aws_iam_role.bluepages_ec2.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
 
 resource "aws_iam_instance_profile" "bluepages" {
   name = "bluepages-ec2-profile"


### PR DESCRIPTION
necessary for #38 . Already ran `tofu apply` and verified that this enabled a successful run of the GH action