### PR TITLE
add csrf related django settings

### DIFF
--- a/bluepages/bluepages/settings.py
+++ b/bluepages/bluepages/settings.py
@@ -204,6 +204,12 @@ SITE_ID = 1
 CRISPY_ALLOWED_TEMPLATE_PACKS = ["bootstrap5"]
 CRISPY_TEMPLATE_PACK = "bootstrap5"
 
+SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+
+CSRF_TRUSTED_ORIGINS_ENV = os.environ.get("CSRF_TRUSTED_ORIGINS")
+if CSRF_TRUSTED_ORIGINS_ENV:
+    CSRF_TRUSTED_ORIGINS = CSRF_TRUSTED_ORIGINS_ENV.split(",")
+
 try:
     from .local_settings import *
 except Exception as e:

--- a/infra/ec2.tf
+++ b/infra/ec2.tf
@@ -31,6 +31,7 @@ resource "aws_instance" "bluepages" {
     db_dump_file_path    = var.db_dump_file_path
     domain_name          = var.domain_name
     ssl_admin_email      = var.ssl_admin_email
+    csrf_trusted_origins = var.csrf_trusted_origins
   })
 
   root_block_device {

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -96,3 +96,8 @@ variable "ssl_admin_email" {
   description = "Admin email for SSL certificate registration (Certbot)"
   type        = string
 }
+
+variable "csrf_trusted_origins" {
+  description = "Comma-separated list of trusted origins for CSRF protection in Django"
+  type        = string
+}

--- a/infra/user_data.tftpl
+++ b/infra/user_data.tftpl
@@ -75,6 +75,7 @@ DB_PASSWORD=${sql_db_password}
 DB_HOST=${sql_host}
 DB_PORT=${sql_port}
 BLUEPAGES_GHCR_PATH=${web_ghcr_image_uri}
+CSRF_TRUSTED_ORIGINS=${csrf_trusted_origins}
 EOF
 
 # Pull the SQL dump from S3 (no credentials needed — uses EC2 IAM role)


### PR DESCRIPTION
I have not deployed this yet! Attempting to resolve CSRF forbidden on the prod deployment. My plan is to merge this, make a new version which will create a new docker image. I'll then SSH into the prod EC2 instance to and add the env var, pull the new docker image, and restart the containers