### PR TITLE
use force-recreate for docker pull

### DIFF
--- a/.github/workflows/deploy-ec2-production.yaml
+++ b/.github/workflows/deploy-ec2-production.yaml
@@ -33,9 +33,8 @@ jobs:
                     --parameters 'commands=[
                     "echo ${{ secrets.GHCR_TOKEN }} | docker login ghcr.io --username ${{ secrets.GHCR_USERNAME }} --password-stdin",
                     "cd /wcbluepages/wcbluepages && git pull origin main",
-                    "docker pull ${{ secrets.WEB_GHCR_IMAGE_URI }}:latest",
                     "docker compose -f docker-compose.prod.yaml down",
-                    "docker compose --env-file .env.prod -f docker-compose.prod.yaml up -d",
+                    "docker compose --env-file .env.prod -f docker-compose.prod.yaml up -d --pull always --force-recreate",
                     "sleep 5",
                     "docker ps --filter name=bluepages_web --format \"{{.Status}}\"",
                     "docker image prune -f"


### PR DESCRIPTION
I am seeing times when the latest image tag is not pulled, hoping this helps